### PR TITLE
build: bump OpenBabel to 3.2.0 (latest upstream release)

### DIFF
--- a/ext/openbabel/extconf.rb
+++ b/ext/openbabel/extconf.rb
@@ -36,10 +36,12 @@ Dir.chdir main_dir do
   end
 end
 
-# Patch: the openbabel-3-1-1 release tag predates upstream PR #2533 and is missing
-# `#include <ctime>` in obutil.h, so it fails to compile on GCC 11+ (clock / CLOCKS_PER_SEC
-# not declared). Inject the include idempotently right after the header guard so the gem
-# builds on a modern toolchain. Newer refs already carry the include and are left untouched.
+# Patch: release tags up to and including openbabel-3-1-1 predate upstream PR #2533 and are
+# missing `#include <ctime>` in obutil.h, so they fail to compile on GCC 11+ (clock /
+# CLOCKS_PER_SEC not declared). Inject the include idempotently right after the header guard
+# so those refs build on a modern toolchain. The default ref (openbabel-3-2-0) and any newer
+# ref already carry the include, so this is a no-op for them — it only matters when building
+# an older ref via the OPENBABEL override.
 obutil_h = File.join(src_dir, "include", "openbabel", "obutil.h")
 if File.exist?(obutil_h)
   contents = File.read(obutil_h)

--- a/lib/openbabel/version.rb
+++ b/lib/openbabel/version.rb
@@ -1,6 +1,6 @@
 module OpenBabel
   # Upstream OpenBabel version — drives the git tag cloned at build time (see extconf.rb).
-  VERSION = '3.1.1'
+  VERSION = '3.2.0'
   # Published gem version: <OpenBabel version>.<gem revision>. Must be a valid Gem::Version.
   GEMVERSION = VERSION + '.1'
 end


### PR DESCRIPTION
## What

Bumps the wrapper gem to build **Open Babel 3.2.0** — the latest upstream release (tag `openbabel-3-2-0`, published 2026-05-26), up from 3.1.1 (March 2020).

- `lib/openbabel/version.rb`: `VERSION` → `3.2.0`. Since `VERSION` derives the build-time git tag (`'openbabel-' + VERSION.gsub('.','-')` → `openbabel-3-2-0`), this single change redirects the native build. `GEMVERSION` follows as **`3.2.0.1`** (valid `Gem::Version`).
- `ext/openbabel/extconf.rb`: the in-tree `<ctime>` patch is **kept** but its comment generalised. 3.2.0 already ships `#include <ctime>` (upstream PR #2533), so the idempotent patch self-skips and is a no-op for the default ref — it now only matters when building an older ref via the `OPENBABEL` override.

## Build confirmed ✅

Ran the full native build end to end on **GCC 15.2.0 / Ruby 3.3.8**:

- `gem build openbabel.gemspec` → `openbabel-3.2.0.1.gem`
- `extconf.rb` clones `openbabel-3-2-0`, configures with cmake (SWIG 4.4.0, "Ruby bindings will be compiled"), `make -j` and `make install` complete cleanly (only deprecation warnings; no errors), `<ctime>` patch correctly skipped.
- Bindings load (`require "openbabel"`, `OBConversion.new`), and the cholesterol smoke test from `test/test_openbabel.rb` passes: **74 atoms, 386.65 g/mol, formula C27H46O**.

> Note: the `test-unit` autorunner crashes in this environment due to a `test-unit 3.6.1` / Ruby 3.3.8 `optparse` incompatibility (unrelated to this change — 3.1.1 fails identically), so the assertions were run directly against the built bindings to confirm correctness.

## Downstream follow-up

`chemotion_ELN` pins the exact gem version string in its `Gemfile` — it will need repinning to `3.2.0.1`. Not part of this PR.